### PR TITLE
IMTA-6156 Enable AD account DB access

### DIFF
--- a/configuration/database/README.md
+++ b/configuration/database/README.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-This project is used to prepare the database to be used by ArchetypeService service.
+This project is used to prepare the database to be used by the SOAP Request service.
 
 ## Pre-Requisites
 
-- JRE / JDK v8
+- JRE / JDK v11
 - Maven v3
 
 ## How to run
@@ -19,7 +19,12 @@ Required environment variables:
 - DATABASE_DB_PASSWORD
 - DATABASE_DB_CONNECTION_STRING
 - BASE_SERVICE_DB_PASSWORD
+- BASE_SERVICE_DB_USER_AD
 
 ### Running migrations
 
 - Execute `mvn clean process-resources`
+
+### Local set up
+
+If you would like to set up the SOAP Request database locally, please use the docker-local repo.

--- a/configuration/database/pom.xml
+++ b/configuration/database/pom.xml
@@ -14,8 +14,6 @@
     <properties>
         <liquibase.version>3.5.3</liquibase.version>
         <sqlserver.version>6.2.1.jre8</sqlserver.version>
-        <azuread.version>1.3.0</azuread.version>
-        <janino.version>3.0.12</janino.version>
     </properties>
 
     <dependencies>
@@ -28,16 +26,6 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>${sqlserver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>adal4j</artifactId>
-            <version>${azuread.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${janino.version}</version>
         </dependency>
     </dependencies>
 
@@ -55,6 +43,7 @@
                     <url>${DATABASE_DB_CONNECTION_STRING}</url>
                     <systemProperties>
                         <serviceDbPassword>${BASE_SERVICE_DB_PASSWORD}</serviceDbPassword>
+                        <serviceDbUserAd>${BASE_SERVICE_DB_USER_AD}</serviceDbUserAd>
                     </systemProperties>
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                 </configuration>

--- a/configuration/database/scripts/migrate.sh
+++ b/configuration/database/scripts/migrate.sh
@@ -6,4 +6,5 @@ liquibase --driver="com.microsoft.sqlserver.jdbc.SQLServerDriver" \
     --username="${DATABASE_DB_USER}" \
     --password="${DATABASE_DB_PASSWORD}" \
     migrate \
-    -DserviceDbPassword="${BASE_SERVICE_DB_PASSWORD}"
+    -DserviceDbPassword="${BASE_SERVICE_DB_PASSWORD}" \
+    -DserviceDbUserAd="${BASE_SERVICE_DB_USER_AD}"

--- a/configuration/database/src/main/resources/changelogs/IMTA-6156-enable-ad-account-access.xml
+++ b/configuration/database/src/main/resources/changelogs/IMTA-6156-enable-ad-account-access.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet author="lynneagleton" id="enable-ad-account-access">
+    <sql>
+      IF NOT EXISTS (
+        SELECT name
+        FROM sys.database_principals
+        WHERE name = '${serviceDbUserAd}')
+      BEGIN
+        CREATE USER [${serviceDbUserAd}] FROM EXTERNAL PROVIDER
+      END
+
+      GRANT SELECT, INSERT, UPDATE, DELETE ON dbo.soaprequest TO [${serviceDbUserAd}];
+      GRANT SELECT, INSERT, UPDATE ON dbo.soaprequest_audit TO [${serviceDbUserAd}];
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/configuration/database/src/main/resources/migrations.xml
+++ b/configuration/database/src/main/resources/migrations.xml
@@ -6,4 +6,5 @@
     <include file="changelogs/create_schema_1.0.xml"/>
     <include file="changelogs/IMTA-3891-create-audit-table-for-soaprequest-1.0.xml"/>
     <include file="changelogs/IMTA-4093-additional-columns-in-soap-audit-table.xml"/>
+    <include file="changelogs/IMTA-6156-enable-ad-account-access.xml"/>
 </databaseChangeLog>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>uk.gov.defra.tracesx</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.12</version>
     </parent>
 
     <dependencies>

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
       aud: ${SECURITY_JWT_AUD}
   datasource:
     driver-class-name: com.microsoft.sqlserver.jdbc.SQLServerDriver
-    url: jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME};user=${DB_USER};password=${DB_PASSWORD};trustServerCertificate=${TRUST_SERVER_CERTIFICATE};hostNameInCertificate=*.database.windows.net;encrypt=true;
+    url: jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME};user=${DB_USER_AD};password=${DB_PASSWORD_AD};trustServerCertificate=${TRUST_SERVER_CERTIFICATE};hostNameInCertificate=*.database.windows.net;encrypt=true;authentication=ActiveDirectoryPassword
     dialect: com.microsoft.sqlserver.jdbc.SQLServerDriver
     continueOnError: true
     initialize: false


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lynn Eagleton (KAINOS) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-6156 Enable AD account DB access](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/39) |
> | **GitLab MR Number** | [39](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/39) |
> | **Date Originally Opened** | Tue, 19 Nov 2019 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Ghost User, Lukasz Kedron (KAINOS), dominik henjes (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

+ Updated config and added new liquibase script to enable usage of AD accounts instead of SQL accounts for DB access.

JIRA ticket: https://eaflood.atlassian.net/browse/IMTA-6156