### PR TITLE
IMTA-6573: Add new configurable parameters

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/soaprequest/PropertySetter.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/soaprequest/PropertySetter.java
@@ -1,0 +1,19 @@
+package uk.gov.defra.tracesx.soaprequest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Security;
+import javax.annotation.PostConstruct;
+
+@Component
+public class PropertySetter {
+
+  @Value("${networking.dnsCacheTtl}")
+  private String dnsCacheTtl;
+
+  @PostConstruct
+  public void setProperty() {
+    Security.setProperty("networkaddress.cache.ttl", dnsCacheTtl);
+  }
+}

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -1,2 +1,4 @@
 server:
   port: 5260
+networking:
+  dnsCacheTtl: ${DNS_CACHE_TTL:20}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
       aud: ${SECURITY_JWT_AUD}
   datasource:
     driver-class-name: com.microsoft.sqlserver.jdbc.SQLServerDriver
-    url: jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME};user=${DB_USER_AD};password=${DB_PASSWORD_AD};trustServerCertificate=${TRUST_SERVER_CERTIFICATE};hostNameInCertificate=*.database.windows.net;encrypt=true;authentication=ActiveDirectoryPassword
+    url: jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME};user=${DB_USER_AD};password=${DB_PASSWORD_AD};trustServerCertificate=${TRUST_SERVER_CERTIFICATE};hostNameInCertificate=*.database.windows.net;encrypt=true;authentication=ActiveDirectoryPassword;socketTimeout=${DB_SOCKET_TIMEOUT:10000};loginTimeout=${DB_LOGIN_TIMEOUT:15};
     dialect: com.microsoft.sqlserver.jdbc.SQLServerDriver
     continueOnError: true
     initialize: false
@@ -62,3 +62,5 @@ audit:
 logging:
   level:
     com.zaxxer.hikari: ${HIKARI_DEBUG_LEVEL:DEBUG}
+networking:
+  dnsCacheTtl: ${DNS_CACHE_TTL:20}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | iwan roberts (KAINOS) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-6573: Add new configurable paramete...](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/45) |
> | **GitLab MR Number** | [45](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/45) |
> | **Date Originally Opened** | Sun, 19 Jan 2020 |
> | **Approved on GitLab by** | Lukasz Kedron (KAINOS), kamil mojek (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

The purpose of this ticket is to make DNS cache TTL and database socket connection timeout configurable.

https://eaflood.atlassian.net/browse/IMTA-6573