### PR TITLE
IMTA-12897 : apply default azure port

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('pipeline-library') _
+@Library('pipeline-library@feature/IMTA-12897-default-port-p3') _
 
 javaPipeline {
     SERVICE_NAME = "soaprequest-microservice"

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -13,6 +13,6 @@ COPY lib/applicationinsights.json /usr/src/soaprequest-service/
 RUN chown jreuser /usr/src/soaprequest-service
 USER jreuser
 
-EXPOSE 4000
+EXPOSE 8080
 
 CMD ["java", "-javaagent:/usr/src/soaprequest-service/applicationinsights-agent.jar", "-jar", "TracesX_SoapRequest.jar"]


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | prabash balasuriya (kainos) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-12897 : apply default azure port](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/75) |
> | **GitLab MR Number** | [75](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/75) |
> | **Date Originally Opened** | Mon, 17 Oct 2022 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Kelly Moore, ramkumar ramagopal (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12897)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-12897-default-port&id=Imports-MS-SoapRequest)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/soaprequest-microservice/job/feature%2FIMTA-12897-default-port/)

### :book: Changes:
* apply default azure port

### :white_check_mark: Selenium Test Run:

PENDING