### PR TITLE
IMTA-14997 fix db migration on liquibase upgrade

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -5,9 +5,6 @@ FROM sndeuxfesacr001.azurecr.io/$LINUX_BASE_IMAGE
 # Needed for running sqlcmd and bcp
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
 
-# Copy and unpack Liquibase
-ADD database/lib/liquibase-3.7.0-bin.tar.gz opt/liquibase
-
 # Copy setup script
 COPY setup.sh /opt
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Apurva Jhunjhunwala (Kainos) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-14997 fix db migration on liquibase...](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/94) |
> | **GitLab MR Number** | [94](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/94) |
> | **Date Originally Opened** | Thu, 7 Dec 2023 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Eugene Fahy (Kainos), Odran Muldoon (Kainos), Toyin Ajani (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-14997
### :book: Changes:
* Removed Add liquibase command from Docker file and lib, to avoid overriding liquibase version to one available in base image.