### PR TITLE
IMTA-16349: use jreuser for java17 image

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,6 +1,8 @@
-ARG BASE_VERSION=jre-17
-FROM sndeuxfesacr001.azurecr.io/$BASE_VERSION AS base
+ARG IMAGE_ACR
+ARG IMAGE_REPOSITORY
+ARG IMAGE_TAG
 
+FROM $IMAGE_ACR/$IMAGE_REPOSITORY:$IMAGE_TAG AS base
 
 USER root
 
@@ -10,6 +12,9 @@ WORKDIR /usr/src/soaprequest-service
 COPY target/TracesX_SoapRequest.jar /usr/src/soaprequest-service/
 COPY lib/applicationinsights-agent.jar /usr/src/soaprequest-service/
 COPY lib/applicationinsights.json /usr/src/soaprequest-service/
+
+RUN chown jreuser /usr/src/soaprequest-service
+USER jreuser
 
 EXPOSE 8080
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Thomas Seelig (Kainos) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-16349: use jreuser for java17 image](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/96) |
> | **GitLab MR Number** | [96](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/96) |
> | **Date Originally Opened** | Thu, 29 Feb 2024 |
> | **Approved on GitLab by** | Eric Kennedy (Kainos), Jana Latzberg (Kainos), Josh Craig (Kainos), philip munaawa1 (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket - IMTA-16349](https://eaflood.atlassian.net/browse/IMTA-16349)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-16349-use-jreuser-for-java17-image&id=Imports-MS-SoapRequest) (no code changes)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/soaprequest-microservice/job/feature%252FIMTA-16349-use-jreuser-for-java17-image/)

### :book: Changes:
* Use jreuser for java17 in dockerfile