### PR TITLE
IMTA-18016: ALVS - Duplicate Database Records created with same requestId

### DIFF
--- a/integration/src/test/java/uk/gov/defra/tracesx/soaprequest/integration/TestBasicEndpoints.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/soaprequest/integration/TestBasicEndpoints.java
@@ -1,13 +1,20 @@
 package uk.gov.defra.tracesx.soaprequest.integration;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.defra.tracesx.common.security.tests.jwt.JwtConstants.BEARER;
 import static uk.gov.defra.tracesx.soaprequest.integration.properties.Properties.SERVICE_BASE_URL;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +30,7 @@ class TestBasicEndpoints {
   private static final String TEST_USERNAME = "testUser";
   private static final String TEST_QUERY = "testQuery";
   private static final String ROLES_CLAIM = "roles";
+
   private String baseUrl;
   private String resourceUrl;
   private SelfSignedTokenClient selfSignedTokenClient;
@@ -93,12 +101,10 @@ class TestBasicEndpoints {
     Response response =
         getSoapRequestByRequestIdAndUsername(soapRequest.getRequestId(), soapRequest.getUsername());
     response.then().statusCode(200);
-    SoapRequestDTO result = response.body().as(SoapRequestDTO.class);
 
-    assertEquals(result.getId(), soapRequest.getId());
-    assertEquals(result.getRequestId(), soapRequest.getRequestId());
-    assertEquals(result.getUsername(), soapRequest.getUsername());
-    assertEquals(result.getQuery(), soapRequest.getQuery());
+    List<SoapRequestDTO> result = response.as(new TypeRef<>() {});
+
+    assertThat(result).singleElement().isEqualTo(soapRequest);
   }
 
   @Test

--- a/service/src/main/java/uk/gov/defra/tracesx/soaprequest/dao/repositories/SoapRequestRepository.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/soaprequest/dao/repositories/SoapRequestRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.defra.tracesx.soaprequest.dao.repositories;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +9,5 @@ import uk.gov.defra.tracesx.soaprequest.dao.entities.SoapRequest;
 @Repository
 public interface SoapRequestRepository extends CrudRepository<SoapRequest, UUID> {
 
-  Optional<SoapRequest> findByRequestId(Long requestId);
+  List<SoapRequest> findAllByRequestId(Long requestId);
 }

--- a/service/src/main/java/uk/gov/defra/tracesx/soaprequest/resource/SoapRequestResource.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/soaprequest/resource/SoapRequestResource.java
@@ -5,6 +5,7 @@ import static uk.gov.defra.tracesx.soaprequest.util.Constants.SOAP_REQUEST_ENDPO
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -65,10 +66,14 @@ public class SoapRequestResource {
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasAuthority('soaprequest.read')")
-  public ResponseEntity<SoapRequestDto> getByRequestId(@RequestParam("requestId") Long requestId) {
+  public ResponseEntity<List<SoapRequestDto>> getAllByRequestId(
+      @RequestParam("requestId") Long requestId) {
     LOGGER.debug("GET requestId: {}", requestId);
-    Optional<SoapRequestDto> soapRequestDto = soapRequestService.getByRequestId(requestId);
-    return ResponseEntity.ok(soapRequestDto.orElseThrow(NotFoundException::new));
+    List<SoapRequestDto> soapRequestDtoList = soapRequestService.getAllByRequestId(requestId);
+    if (soapRequestDtoList.isEmpty()) {
+      throw new NotFoundException();
+    }
+    return ResponseEntity.ok(soapRequestDtoList);
   }
 
   @DeleteMapping(value = "/{id}")

--- a/service/src/main/java/uk/gov/defra/tracesx/soaprequest/service/SoapRequestService.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/soaprequest/service/SoapRequestService.java
@@ -1,5 +1,8 @@
 package uk.gov.defra.tracesx.soaprequest.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,11 +45,14 @@ public class SoapRequestService {
     return optionalSoapRequestDto;
   }
 
-  public Optional<SoapRequestDto> getByRequestId(Long id) {
-    Optional<SoapRequestDto> optionalSoapRequestDto = soapRequestRepository.findByRequestId(id)
-        .map(SoapRequestDto::from);
-    optionalSoapRequestDto.ifPresent(auditServiceWrapper::read);
-    return optionalSoapRequestDto;
+  public List<SoapRequestDto> getAllByRequestId(Long id) {
+    List<SoapRequestDto> soapRequestDtoList = new ArrayList<>();
+    for (SoapRequest soapRequest : soapRequestRepository.findAllByRequestId(id)) {
+      SoapRequestDto mapped = SoapRequestDto.from(soapRequest);
+      auditServiceWrapper.read(mapped);
+      soapRequestDtoList.add(mapped);
+    }
+    return Collections.unmodifiableList(soapRequestDtoList);
   }
 
   public void deleteData(UUID id) {

--- a/service/src/test/java/uk/gov/defra/tracesx/soaprequest/resource/SoapRequestResourceTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/soaprequest/resource/SoapRequestResourceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,25 +132,25 @@ class SoapRequestResourceTest {
   }
 
   @Test
-  void getByRequestIdReturnsEntityFromService() {
+  void getAllByRequestIdReturnsEntityFromService() {
     // Given
-    when(soapRequestService.getByRequestId(any())).thenReturn(Optional.ofNullable(requestBody));
+    when(soapRequestService.getAllByRequestId(any())).thenReturn(List.of(requestBody));
 
     // When
-    ResponseEntity<SoapRequestDto> entity = soapRequestResource.getByRequestId(requestId);
+    ResponseEntity<List<SoapRequestDto>> entity = soapRequestResource.getAllByRequestId(requestId);
 
     // Then
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(entity.getBody()).isEqualTo(requestBody);
+    assertThat(entity.getBody()).isEqualTo(List.of(requestBody));
   }
 
   @Test
-  void getByRequestIdThrowsNotFoundOnNonExistentRequestId() {
+  void getAllByRequestIdThrowsNotFoundOnNonExistentRequestId() {
     // Given
-    when(soapRequestService.getByRequestId(any())).thenReturn(Optional.empty());
+    when(soapRequestService.getAllByRequestId(any())).thenReturn(List.of());
 
     // When
-    assertThrows(NotFoundException.class, () -> soapRequestResource.getByRequestId(requestId));
+    assertThrows(NotFoundException.class, () -> soapRequestResource.getAllByRequestId(requestId));
   }
 
   @Test


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kalpana muddapu (Kainos) |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-18016: ALVS - Duplicate Database Re...](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/102) |
> | **GitLab MR Number** | [102](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/102) |
> | **Date Originally Opened** | Mon, 30 Sep 2024 |
> | **Approved on GitLab by** | Jonathan Magee, Lewis Birks (Kainos), Mayuresh Kadu (Kainos), Peter Rooke (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18016)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18016-duplicate-records-with-same-id&id=Imports-MS-SoapRequest)

### :book: Changes:

- - Modified endpoint (https://soaprequest-microservice-green-prd.azurewebsites.net/soaprequest?requestId=1719988501005) to return list of records
- Updated unit and integration tests