### PR TITLE
IMTA-19310 remove vulnerability in spring-security-web

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -10,11 +10,23 @@
 
     <parent>
         <groupId>uk.gov.defra.tracesx</groupId>
-        <artifactId>spring-boot-parent</artifactId>
-        <version>4.0.47</version>
+        <artifactId>TracesX-SpringBoot-Common-Parent</artifactId>
+        <version>4.0.6</version>
     </parent>
 
     <dependencies>
+        <dependency>
+            <groupId>uk.gov.defra.tracesx</groupId>
+            <artifactId>TracesX-SpringBoot-Common-Health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.defra.tracesx</groupId>
+            <artifactId>TracesX-SpringBoot-Common-Logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.defra.tracesx</groupId>
+            <artifactId>TracesX-SpringBoot-Common-Security</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-19310 remove vulnerability in sprin...](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/110) |
> | **GitLab MR Number** | [110](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/110) |
> | **Date Originally Opened** | Tue, 11 Feb 2025 |
> | **Approved on GitLab by** | andrew roberts (Equal experts) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

update to latest TracesX-SpringBoot-Common-Parent (which updates underlying Spring Boot version)

also add direct dependencies on
- TracesX-SpringBoot-Common-Health
- TracesX-SpringBoot-Common-Logging
- TracesX-SpringBoot-Common-Security
(these used to be brought in as dependencies by the previous parent POM)