### PR TITLE
IMTA-18903 - Remove Basic Auth from calls to Permissions service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The following properties are used by the application (see required values in the
      APPLICATIONINSIGHTS_CONNECTION_STRING
      API_VERSION
      ENV_DOMAIN
-     PERMISSIONS_SERVICE_PASSWORD
      PROTOCOL
      SECURITY_JWT_JWKS
      SECURITY_JWT_ISS

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.gov.defra.tracesx</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.0.42</version>
+        <version>4.0.43</version>
     </parent>
 
     <dependencies>

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -28,8 +28,6 @@ permissions:
     host: permissions${ENV_DOMAIN}
     port: 443
     url: ${PROTOCOL}://permissions${ENV_DOMAIN}
-    user: importer
-    password: ${PERMISSIONS_SERVICE_PASSWORD}
     connectionTimeout: 3000
     readTimeout: 3000
   security:


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @trinhchuongee |
> | **GitLab Project** | [imports/soaprequest-microservice](https://giteux.azure.defra.cloud/imports/soaprequest-microservice) |
> | **GitLab Merge Request** | [IMTA-18903 - Remove Basic Auth from call...](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/106) |
> | **GitLab MR Number** | [106](https://giteux.azure.defra.cloud/imports/soaprequest-microservice/merge_requests/106) |
> | **Date Originally Opened** | Fri, 25 Oct 2024 |
> | **Approved on GitLab by** | @crosslandwa, @davidsavi, Guru Prasath (esynergy), Harrison Duffield (Kainos), Łukasz Pietrynczak (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18903)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18903-remove-basic-auth-from-calls-to-permissions-service&id=Imports-MS-SoapRequest)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/soaprequest-microservice/job/feature%2FIMTA-18903-remove-basic-auth-from-calls-to-permissions-service/)

### :book: Changes:

- Update spring boot parent which removes the passing of basic auth credentials to permissions service in favour of JWT auth